### PR TITLE
Fixed typo in topics section

### DIFF
--- a/articles/event-grid/concepts.md
+++ b/articles/event-grid/concepts.md
@@ -37,7 +37,7 @@ For information about implementing any of the supported Event Grid sources, see 
 
 The event grid topic provides an endpoint where the source sends events. The publisher creates the event grid topic, and decides whether an event source needs one topic or more than one topic. A topic is used for a collection of related events. To respond to certain types of events, subscribers decide which topics to subscribe to.
 
-System topics are built-in topics provided by Azure services. You don't see system topics in your Azure subscription because the publisher owns the topics, but you can subscribe to them. To subscribe, you provide information about the resource you want to receive events from. As long as you have access the resource, you can subscribe to its events.
+System topics are built-in topics provided by Azure services. You don't see system topics in your Azure subscription because the publisher owns the topics, but you can subscribe to them. To subscribe, you provide information about the resource you want to receive events from. As long as you have access to the resource, you can subscribe to its events.
 
 Custom topics are application and third-party topics. When you create or are assigned access to a custom topic, you see that custom topic in your subscription.
 


### PR DESCRIPTION
Under topics, changed "As long as you have access the resource" to  "As long as you have access to the resource".